### PR TITLE
Clear the input box after adding a task

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,18 +33,17 @@ function listElement() {
 
 // listElement();
 
-function addTasksWhenClick() {
+function addTask() {
   if (lengthOfInput() > 0) {
     listElement();
     input.value = "";
   }
 }
 
-enterButton.onclick = () => addTasksWhenClick();
+enterButton.onclick = () => addTask();
 
 input.addEventListener("keypress", () => {
-  if (lengthOfInput() > 0 && event.which === 13) {
-    listElement();
-    input.value = "";
+  if (event.which === 13) {
+    addTask();
   }
 });

--- a/index.js
+++ b/index.js
@@ -1,50 +1,50 @@
-const enterButton= document.getElementById("enter");
-const input= document.getElementById("input");
-const list= document.querySelector('ul');
+const enterButton = document.getElementById("enter");
+const input = document.getElementById("input");
+const list = document.querySelector("ul");
 
-const tasks = document.querySelector("li")
+const tasks = document.querySelector("li");
 // console.log (enterButton, input, list, item);
 
-
-function lengthOfInput(){
-    return input.value.length;
+function lengthOfInput() {
+  return input.value.length;
 }
 
-function listElement (){
-    const li = document.createElement("li");
-    li.appendChild(document.createTextNode(input.value));
-    list.appendChild(li);
+function listElement() {
+  const li = document.createElement("li");
+  li.appendChild(document.createTextNode(input.value));
+  list.appendChild(li);
 
+  function crossOutTask() {
+    li.classList.toggle("done");
+  }
+  li.addEventListener("click", crossOutTask);
 
-    function crossOutTask () {
-        li.classList.toggle('done');
-    }
-    li.addEventListener("click", crossOutTask);
-
-    const deleteBtn = document.createElement("button");
-    deleteBtn.appendChild(document.createTextNode("X"));
-    li.appendChild(deleteBtn);
-    deleteBtn.addEventListener("click", deleteListItem);
-    function deleteListItem () {
-        li.classList.add("delete");
-        setTimeout(function () {
-            li.style.display = "none";
-        }, 500);
-    }
+  const deleteBtn = document.createElement("button");
+  deleteBtn.appendChild(document.createTextNode("X"));
+  li.appendChild(deleteBtn);
+  deleteBtn.addEventListener("click", deleteListItem);
+  function deleteListItem() {
+    li.classList.add("delete");
+    setTimeout(function () {
+      li.style.display = "none";
+    }, 500);
+  }
 }
 
 // listElement();
 
-function addTasksWhenClick (){
-    if (lengthOfInput() > 0){
-        listElement();
-    }
+function addTasksWhenClick() {
+  if (lengthOfInput() > 0) {
+    listElement();
+    input.value = "";
+  }
 }
 
 enterButton.onclick = () => addTasksWhenClick();
 
-input.addEventListener('keypress', ()=>{
-    if(lengthOfInput()>0 && event.which===13){
-        listElement();
-    }
-})
+input.addEventListener("keypress", () => {
+  if (lengthOfInput() > 0 && event.which === 13) {
+    listElement();
+    input.value = "";
+  }
+});


### PR DESCRIPTION
This improves the user's experience as the user no longer needs to clear the input box after adding a task, to add a new task. Apologies if you do not like 2 spaces for a tab instead of 4, and double quotes instead of single. I use Prettier and this is its default behaviour.